### PR TITLE
Refixing joomscan bootloader to pass args

### DIFF
--- a/joomscan.sh
+++ b/joomscan.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-perl ~/toolkit/joomscan/joomscan.pl
+perl ~/toolkit/joomscan/joomscan.pl "$@"


### PR DESCRIPTION
Re-Adding the ability to pass arguments to the underlying pearl script through the boot loader bash script. Closes #9.