### PR TITLE
Add Docker Hub GH Action

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,24 @@
+name: Build & Push to Dockerhub
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+
+    - name: Build & Push to Dockerhub
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: hackersploit/bugbountytoolkit
+        tags: latest


### PR DESCRIPTION
This PR uses Github Actions to automatically build the Docker image and push to Docker Hub (ensuring the image on Docker Hub and code from Github master branch are always in sync).

Before merging (assuming you'd like this feature), simply go into the [Repo Settings > Secrets](https://github.com/AlexisAhmed/BugBountyToolkit/settings/secrets) and add the following variables:

- `DOCKER_USERNAME` (the username you use for Docker Hub)
- `DOCKER_PASSWORD` (the username you use for Docker Hub)